### PR TITLE
install gitlab-ce package through packagecloud

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -178,21 +178,10 @@ class gitlab::install inherits ::gitlab {
   validate_string($download_location)
   info("omnibus_filename is \'${omnibus_filename}\'")
 
-  # Use wget or curl to download gitlab
-  exec { 'download gitlab':
-    command => "${::gitlab::puppet_fetch_client} ${download_location}/${omnibus_filename} ${gitlab_url}",
-    path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/usr/local/sbin',
-    cwd     => $download_location,
-    creates => "${download_location}/${omnibus_filename}",
-    timeout => 1800,
-  }
-  # Install gitlab with the appropriate package manager (rpm or dpkg)
+  # Install gitlab with the default package manager (rpm or apt)
   package { 'gitlab':
-    ensure   => latest,
+    ensure   => "${::gitlab::gitlab_branch}",
     name     => 'gitlab-ce',
-    source   => "${download_location}/${omnibus_filename}",
-    provider => $package_manager,
-    require  => Exec['download gitlab'],
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,11 +39,11 @@ class gitlab::params {
   }
 
   # Gitlab server settings
-  $gitlab_branch         = undef   # Required: (e.g. '7.0.0') - Branch to download and install
-  $gitlab_release        = 'basic' # 'basic' | 'enterprise' - (default: basic)
-  $gitlab_download_link  = undef   # e.g. 'https://secret_url/ubuntu-12.04/gitlab_7.0.0-omnibus-1_amd64.deb', Enterprise only
+  $gitlab_branch         = 'present' # Required: (e.g. '7.0.0') - Branch to download and install
+  $gitlab_release        = 'basic'  # 'basic' | 'enterprise' - (default: basic)
+  $gitlab_download_link  = undef    # e.g. 'https://secret_url/ubuntu-12.04/gitlab_7.0.0-omnibus-1_amd64.deb', Enterprise only
 
-  $external_url          = undef # Required: (eg. 'http://gitlab.example.com') - Sets nginx listening address
+  $external_url          = undef    # Required: (eg. 'http://gitlab.example.com') - Sets nginx listening address
 
   #
   # 1. GitLab app settings


### PR DESCRIPTION
installs gitlab-ce version present or version provided by gitlab::gitlab_branch using the default package manager (apt/yum) without wget
