### PR TITLE
introduce new parameter backup_pg_path to manage pg_dump version to u…

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -29,6 +29,7 @@ class gitlab::backup (
   $backup_month    = undef,
   $backup_monthday = undef,
   $backup_weekday  = undef,
+  $backup_pg_path  = undef,
 ) inherits ::gitlab {
 
   # Execute rake backup
@@ -40,6 +41,21 @@ class gitlab::backup (
     month    => $backup_month,
     monthday => $backup_monthday,
     weekday  => $backup_weekday,
+  }
+
+  if ( $backup_pg_path ) {
+    file { '/opt/gitlab/embedded/bin/pg_dump':
+      ensure   => 'link',
+      target   => "${backup_pg_path}/pg_dump",
+    }
+    file { '/opt/gitlab/embedded/bin/pg_dumpall':
+      ensure   => 'link',
+      target   => "${backup_pg_path}/pg_dumpall",
+    }
+    file { '/opt/gitlab/embedded/bin/pg_restore':
+      ensure   => 'link',
+      target   => "${backup_pg_path}/pg_restore",
+    }
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -800,6 +800,7 @@ class gitlab (
   $backup_month                = $::gitlab::params::backup_month,
   $backup_monthday             = $::gitlab::params::backup_monthday,
   $backup_weekday              = $::gitlab::params::backup_weekday,
+  $backup_pg_path              = $::gitlab::params::backup_pg_path,
   $backup_upload_connection    = $::gitlab::params::backup_upload_connection,
   $backup_upload_remote_directory = $::gitlab::params::backup_upload_remote_directory,
   $gitlab_shell_path           = $::gitlab::params::gitlab_shell_path,
@@ -1001,6 +1002,7 @@ class gitlab (
       backup_month    => $backup_month,
       backup_monthday => $backup_monthday,
       backup_weekday  => $backup_weekday,
+      backup_pg_path  => $backup_pg_path,
     }
 
     Class['::gitlab::install'] -> Class['::gitlab::backup']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -129,6 +129,8 @@ class gitlab::params {
   $backup_monthday             = undef
   $backup_weekday              = undef
 
+  $backup_pg_path              = undef # set to '/usr/bin' if a newer version of pg_dump is needed for backup
+
   $backup_upload_connection    = undef # Backup to fog http://bit.ly/1t5nAv5
   $backup_upload_remote_directory = undef # Where to store backups in fog http://bit.ly/1t5nAv5
   $gitlab_shell_path           = undef # '/opt/gitlab/embedded/service/gitlab-shell/'


### PR DESCRIPTION
…se for gitlab-rake gitlab:backup:*

because gitlab omnibus still uses postgresql version 9.2.9 it is not possible to create backups of newer postgresql databases like 9.3 or 9.4. By setting backup_pg_path to /usr/bin, gitlab-rake gitlab:backup:\* uses the provided application in the path. (for pg_dump, pg_dumpall and pg_restore)
